### PR TITLE
Reference npmjs for postgis-vt-util

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "access": "public"
   },
   "dependencies": {
-    "postgis-vt-util": "git+https://github.com/mapbox/postgis-vt-util.git#v0.3.0"
+    "postgis-vt-util": "0.3.0"
   }
 }


### PR DESCRIPTION
I'm not switching to `@mapbox/postgis-vt-util` because that would break documentation in half a dozen places as well as external deploy scripts for no gain.

This will need a new release