### PR TITLE
Switch to EPSG 3857

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It's probably easiest to grab an PBF of OSM data from [Mapzen](https://mapzen.co
 ```sh
 createdb gis
 psql -d gis -c 'CREATE EXTENSION postgis; CREATE EXTENSION hstore;'
-osm2pgsql -d gis -E 900913 --hstore ~/path/to/data.osm.pbf
+osm2pgsql -d gis -E 3857 --hstore ~/path/to/data.osm.pbf
 ```
 
 You can find a more detailed guide to setting up a database and loading data with osm2pgsql at [switch2osm.org](http://switch2osm.org/loading-osm-data/).
@@ -21,7 +21,6 @@ curl -O http://data.openstreetmapdata.com/water-polygons-split-3857.zip
 unzip water-polygons-split-3857.zip && rm water-polygons-split-3857.zip
 cd water-polygons-split-3857
 shp2pgsql -I -s 3857 -g way water_polygons.shp water_polygons | psql -Xqd gis
-psql -Xqd gis -c "select UpdateGeometrySRID('', 'water_polygons', 'way', 900913);"
 ```
 
 Then some custom functions and indexes


### PR DESCRIPTION
Fixes #52 

The rendering tables and water tables need to be in a consistent SRID for admin processing.

The definitions of 900913 and 3857 are identical, so both work with rendering where SRID is ignored on the `&&` operator.

It really doesn't matter which projection is used, so long as its the same. The previous instructions went for 900913, but the problem is it's not a real EPSG code and recent versions of Proj include it under "extra" not "epsg". This causes `-E 900913` to fail in osm2pgsql, even if it'd work in PostGIS. Switching everything to 3857 is a bigger change, but more desirable.

No reimport is required - if the import worked and admin boundaries processed correctly, everything worked.