### PR TITLE
Filter out not-languages when extracting names

### DIFF
--- a/sql/names.sql
+++ b/sql/names.sql
@@ -11,8 +11,10 @@ CREATE OR REPLACE FUNCTION extract_names (tags hstore)
           FROM each(tags)
           WHERE key LIKE 'name:%'
       ) AS s(key, value)
+      WHERE key NOT LIKE '%:%' -- Anything with a : still is a multi-level one, and not a simple language code
+      AND key !~ '.*\d.*' -- matches something like name:en1
+      AND key NOT IN ('prefix', 'genitive', 'etymology', 'botanical', 'source', 'left', 'right') -- blacklist common not-languages
   $$
 LANGUAGE SQL
 IMMUTABLE
 STRICT;
-


### PR DESCRIPTION
A test

```
# SELECT extract_names('"name:en"=>"a", "name:en1"=>"b", "name:en:wikidata"=>"c", "name:genitive"=>"d"');
 extract_names
---------------
 "en"=>"a"
(1 row)
```