### PR TITLE
Always specify AS keyword for column alias

### DIFF
--- a/data.yml
+++ b/data.yml
@@ -644,7 +644,7 @@ Layer:
       srid: ''
       table: |
         (
-        SELECT osm_id, 'default' AS shield, way, name, name_ ref, reflen, len FROM (
+        SELECT osm_id, 'default' AS shield, way, name, name_ AS ref, reflen, len FROM (
         SELECT
             osm_id,
             way,


### PR DESCRIPTION
so tilelive-tmsource doesn't break