### PR TITLE
Bumping postgis-vt-util

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,10 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "postgis-vt-util": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/postgis-vt-util/-/postgis-vt-util-0.3.0.tgz",
-      "integrity": "sha1-xHQ6vE169J5wMtjMpW81DEfu4Hk="
+    "@kartotherian/postgis-vt-util": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@kartotherian/postgis-vt-util/-/postgis-vt-util-0.3.1.tgz",
+      "integrity": "sha512-DmH6Dxv87N/c2Iv20bdqSvyf+lZkym/QwjQwJKtS5wb4CG62mmTWAMNKaCZMEa5ECUKPgwuQ+yoxlVj3y1WrIQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "access": "public"
   },
   "dependencies": {
-    "postgis-vt-util": "0.3.0"
+    "@kartotherian/postgis-vt-util": "0.3.1"
   }
 }


### PR DESCRIPTION
postgis-vt-util is now published under kartotherian npm organization and
the version 0.3.1, which is published, have a security patch.