### PR TITLE
Avoid AccessShareLock on populate_admin

### DIFF
--- a/sql/admin.sql
+++ b/sql/admin.sql
@@ -12,13 +12,13 @@ CREATE TABLE IF NOT EXISTS admin (LIKE planet_osm_roads INCLUDING ALL);
 CREATE OR REPLACE FUNCTION populate_admin() RETURNS void AS
 $$
 DECLARE
-	row admin%rowtype;
+	row planet_osm_roads%rowtype;
 	way geometry;
 	water geometry;
 	result geometry;
 	len int;
 BEGIN
-	CREATE TABLE admin_new (LIKE admin INCLUDING ALL);
+	CREATE TABLE admin_new (LIKE planet_osm_roads INCLUDING ALL);
 
 	-- Let the datasource to perform precise filtering, but just don't pull all the crap here
 	FOR row IN SELECT * FROM planet_osm_roads WHERE boundary='administrative' AND admin_level IN ('2', '4') LOOP
@@ -71,11 +71,11 @@ LANGUAGE plpgsql;
 --
 -- Inserts 1 row per sub-geometry into the new admin table
 --
--- @param row admin: Row to insert
+-- @param row planet_osm_roads: Row to insert
 -- @param LineString|MultiLineString geom: Geometry to set for this row
 -- @param bool maritime: Whether the border is maritime
 --
-CREATE OR REPLACE FUNCTION insert_admin_rows(theRow admin, geom geometry, maritime bool) RETURNS void AS
+CREATE OR REPLACE FUNCTION insert_admin_rows(theRow planet_osm_roads, geom geometry, maritime bool) RETURNS void AS
 $$
 DECLARE
 	i int;
@@ -98,7 +98,7 @@ LANGUAGE plpgsql;
 -- @param row theRow: Row to insert
 -- @param LineString geom: Geometry to set for this row
 --
-CREATE OR REPLACE FUNCTION insert_admin_row(theRow admin, geom geometry(LineString)) RETURNS void AS
+CREATE OR REPLACE FUNCTION insert_admin_row(theRow planet_osm_roads, geom geometry(LineString)) RETURNS void AS
 $$
 BEGIN
 	theRow.way := geom;

--- a/sql/admin.sql
+++ b/sql/admin.sql
@@ -5,7 +5,9 @@
 CREATE TABLE IF NOT EXISTS admin (LIKE planet_osm_roads INCLUDING ALL);
 
 --
--- Populates admin table. Slow, so run only sparingly in a cronjob
+-- Populates admin table. Slow, so run only sparingly in a cronjob. To avoid lock that will
+-- make tilerator crash (T204047), a second table is created to store new data and then it 
+-- replaces the old admin table
 --
 CREATE OR REPLACE FUNCTION populate_admin() RETURNS void AS
 $$
@@ -16,7 +18,7 @@ DECLARE
 	result geometry;
 	len int;
 BEGIN
-	TRUNCATE TABLE admin;
+	CREATE TABLE admin_new (LIKE admin INCLUDING ALL);
 
 	-- Let the datasource to perform precise filtering, but just don't pull all the crap here
 	FOR row IN SELECT * FROM planet_osm_roads WHERE boundary='administrative' AND admin_level IN ('2', '4') LOOP
@@ -43,6 +45,8 @@ BEGIN
 			END IF;
 		END IF;
 	END LOOP;
+	DROP TABLE admin;
+	ALTER TABLE admin_new RENAME TO admin;
 END
 $$
 LANGUAGE plpgsql;
@@ -65,7 +69,7 @@ LANGUAGE plpgsql;
 
 
 --
--- Inserts 1 row per sub-geometry into the admin table
+-- Inserts 1 row per sub-geometry into the new admin table
 --
 -- @param row admin: Row to insert
 -- @param LineString|MultiLineString geom: Geometry to set for this row
@@ -89,7 +93,7 @@ $$
 LANGUAGE plpgsql;
 
 --
--- Inserts one row into the admin table
+-- Inserts one row into the new admin table
 --
 -- @param row theRow: Row to insert
 -- @param LineString geom: Geometry to set for this row
@@ -98,7 +102,7 @@ CREATE OR REPLACE FUNCTION insert_admin_row(theRow admin, geom geometry(LineStri
 $$
 BEGIN
 	theRow.way := geom;
-	INSERT INTO admin VALUES(theRow.*);
+	INSERT INTO admin_new VALUES(theRow.*);
 END
 $$
 LANGUAGE plpgsql;


### PR DESCRIPTION
Tilerator ongoing process try to read the admin table while
populate_admin runs. To avoid that, the script will create a new table
to store new data and then will drop admin table and replace it with the
new one.

Bug: T204047