### PR TITLE
Fixing populate_admin for initial import

### DIFF
--- a/sql/admin.sql
+++ b/sql/admin.sql
@@ -81,7 +81,9 @@ BEGIN
 		PERFORM insert_admin_row(theRow, geom);
 	ELSE
 		FOR i IN 1..ST_NumGeometries(geom) LOOP -- Composite geometry, insert one row per subgeometry
-			PERFORM insert_admin_row(theRow, ST_GeometryN(geom, i));
+			IF GeometryType(ST_GeometryN(geom, i)) = 'LINESTRING' THEN -- Ensure geometry has the type LINESTRING
+				PERFORM insert_admin_row(theRow, ST_GeometryN(geom, i));
+			END IF;
 		END LOOP;
 	END IF;
 END


### PR DESCRIPTION
The populate_admin script is crashing during initial import due to
unexpected behavior that throws a mismatch of geometry types. This might
be happening because some data derivation between geometry intersections
that result on some geometry of type point instead of linestring. It
doesn't happen on production due to a outdated water_polygon table.

Bug: [T205462](https://phabricator.wikimedia.org/T205462)