### PR TITLE
Do not render bays

### DIFF
--- a/data.xml
+++ b/data.xml
@@ -136,7 +136,7 @@ SELECT osm_id, way
   FROM planet_osm_polygon
   WHERE
     (
-      "natural" IN ('water', 'bay')
+      "natural" = 'water'
       OR waterway IS NOT NULL
       OR landuse = 'reservoir'
       OR landuse = 'pond'

--- a/data.yml
+++ b/data.yml
@@ -139,7 +139,7 @@ Layer:
           FROM planet_osm_polygon
           WHERE
             (
-              "natural" IN ('water', 'bay')
+              "natural" = 'water'
               OR waterway IS NOT NULL
               OR landuse = 'reservoir'
               OR landuse = 'pond'


### PR DESCRIPTION
Bays generally overlap larger bodies of water that are rendered as water anyway. This intends to make islands not hidden by bays.

Bug: [T199469](https://phabricator.wikimedia.org/T199469)