### PR TITLE
Admin layer: Query only administrative boundaries

### DIFF
--- a/sql/layers/layer_admin.sql
+++ b/sql/layers/layer_admin.sql
@@ -25,6 +25,8 @@ AS $BODY$
     admin
   WHERE
     maritime <> TRUE
+    AND
+    tags->'boundary' = 'administrative'    -- TODO: Remove when we filter out elements in imposm
     AND (
       (
         admin_level = '2' AND zoom_level >= 2 


### PR DESCRIPTION
Fix issues were `admin_level=2` boundaries were rendered as borders regardless if it was administrative boundaries (eg. nature reserves)