### PR TITLE
Remove UTF-8 BOM symbol that introduces failures on sql imports

### DIFF
--- a/sql/helpers/functions.sql
+++ b/sql/helpers/functions.sql
@@ -1,4 +1,4 @@
-﻿--
+--
 -- Safe string to int conversion, on invalid input retrns 0 instead of raising an error
 --
 CREATE OR REPLACE FUNCTION to_int(s TEXT) RETURNS INTEGER


### PR DESCRIPTION
While trying to cleanup kartodock this issue makes `make osm` fail when importing the sql files. Diff is not really showing the issue:

```
\357\273\277--
-- Safe string to int conversion, on invalid input retrns 0 instead of raising an error
--
CREATE OR REPLACE FUNCTION to_int(s TEXT) RETURNS INTEGER
AS $$
```

Fixed using dos2unix